### PR TITLE
Need to lock down Jenkins' slack plugin to particular version.

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -33,7 +33,7 @@ ansicolor
 instant-messaging
 jabber
 notification
-slack
+slack:1.8.1
 script-security
 durable-task
 git-server


### PR DESCRIPTION
Latest 2.x upstream is preventing Jenkins from loading properly.  More info can be found here:  https://github.com/jenkinsci/slack-plugin/issues/188.  By reverting the slack plugin to 1.8.1, Jenkins is able to load and perform build as normal.