### PR TITLE
#6 - Adding this parameter will let the jobs run correctly until the …

### DIFF
--- a/jobs/adapter/config.xml
+++ b/jobs/adapter/config.xml
@@ -142,7 +142,9 @@
   <buildWrappers>
     <org.jenkinsci.plugins.buildnamesetter.BuildNameSetter plugin="build-name-setter@1.3">
       <template>${GIT_REVISION,length=8}</template>
-    </org.jenkinsci.plugins.buildnamesetter.BuildNameSetter>
+      <runAtStart>true</runAtStart>
+      <runAtEnd>true</runAtEnd>
+   </org.jenkinsci.plugins.buildnamesetter.BuildNameSetter>
   </buildWrappers>
   <prebuilders/>
   <postbuilders/>

--- a/jobs/amq-plugin/config.xml
+++ b/jobs/amq-plugin/config.xml
@@ -142,6 +142,8 @@
   <buildWrappers>
     <org.jenkinsci.plugins.buildnamesetter.BuildNameSetter plugin="build-name-setter@1.3">
       <template>${GIT_REVISION,length=8}</template>
+      <runAtStart>true</runAtStart>
+      <runAtEnd>true</runAtEnd>
     </org.jenkinsci.plugins.buildnamesetter.BuildNameSetter>
   </buildWrappers>
   <prebuilders/>

--- a/jobs/antenna/config.xml
+++ b/jobs/antenna/config.xml
@@ -143,6 +143,8 @@
   <buildWrappers>
     <org.jenkinsci.plugins.buildnamesetter.BuildNameSetter plugin="build-name-setter@1.3">
       <template>${GIT_REVISION,length=8}</template>
+      <runAtStart>true</runAtStart>
+      <runAtEnd>true</runAtEnd>
     </org.jenkinsci.plugins.buildnamesetter.BuildNameSetter>
   </buildWrappers>
   <prebuilders/>

--- a/jobs/app/config.xml
+++ b/jobs/app/config.xml
@@ -136,6 +136,8 @@ tar -czf target/app.tar.gz --exclude=target *</command>
     </ruby-proxy-object>
     <org.jenkinsci.plugins.buildnamesetter.BuildNameSetter plugin="build-name-setter@1.3">
       <template>${GIT_REVISION,length=8}</template>
+      <runAtStart>true</runAtStart>
+      <runAtEnd>true</runAtEnd>
     </org.jenkinsci.plugins.buildnamesetter.BuildNameSetter>
   </buildWrappers>
 </project>

--- a/jobs/cms-admin/config.xml
+++ b/jobs/cms-admin/config.xml
@@ -142,6 +142,8 @@
   <buildWrappers>
     <org.jenkinsci.plugins.buildnamesetter.BuildNameSetter plugin="build-name-setter@1.3">
       <template>${GIT_REVISION,length=8}</template>
+      <runAtStart>true</runAtStart>
+      <runAtEnd>true</runAtEnd>
     </org.jenkinsci.plugins.buildnamesetter.BuildNameSetter>
   </buildWrappers>
   <prebuilders/>

--- a/jobs/cms-db-package/config.xml
+++ b/jobs/cms-db-package/config.xml
@@ -100,6 +100,8 @@ shasum -a 256 cms-db-pkg-$VERSION.tar.gz &gt; cms-db-pkg-$VERSION.tar.gz.sha1</c
   <buildWrappers>
     <org.jenkinsci.plugins.buildnamesetter.BuildNameSetter plugin="build-name-setter@1.3">
       <template>${ENV,var=&quot;VERSION&quot;}</template>
+      <runAtStart>true</runAtStart>
+      <runAtEnd>true</runAtEnd>
     </org.jenkinsci.plugins.buildnamesetter.BuildNameSetter>
   </buildWrappers>
 </project>

--- a/jobs/cmsdal/config.xml
+++ b/jobs/cmsdal/config.xml
@@ -143,6 +143,8 @@
   <buildWrappers>
     <org.jenkinsci.plugins.buildnamesetter.BuildNameSetter plugin="build-name-setter@1.3">
       <template>${GIT_REVISION,length=8}</template>
+      <runAtStart>true</runAtStart>
+      <runAtEnd>true</runAtEnd>
     </org.jenkinsci.plugins.buildnamesetter.BuildNameSetter>
   </buildWrappers>
   <prebuilders/>

--- a/jobs/commons/config.xml
+++ b/jobs/commons/config.xml
@@ -135,6 +135,8 @@
   <buildWrappers>
     <org.jenkinsci.plugins.buildnamesetter.BuildNameSetter plugin="build-name-setter@1.3">
       <template>${GIT_REVISION,length=8}</template>
+      <runAtStart>true</runAtStart>
+      <runAtEnd>true</runAtEnd>
     </org.jenkinsci.plugins.buildnamesetter.BuildNameSetter>
   </buildWrappers>
   <prebuilders/>

--- a/jobs/controller/config.xml
+++ b/jobs/controller/config.xml
@@ -142,6 +142,8 @@
   <buildWrappers>
     <org.jenkinsci.plugins.buildnamesetter.BuildNameSetter plugin="build-name-setter@1.5.1">
       <template>${GIT_REVISION,length=8}</template>
+      <runAtStart>true</runAtStart>
+      <runAtEnd>true</runAtEnd>
     </org.jenkinsci.plugins.buildnamesetter.BuildNameSetter>
   </buildWrappers>
   <prebuilders/>

--- a/jobs/daq/config.xml
+++ b/jobs/daq/config.xml
@@ -142,6 +142,8 @@
   <buildWrappers>
     <org.jenkinsci.plugins.buildnamesetter.BuildNameSetter plugin="build-name-setter@1.5.1">
       <template>${GIT_REVISION,length=8}</template>
+      <runAtStart>true</runAtStart>
+      <runAtEnd>true</runAtEnd>
     </org.jenkinsci.plugins.buildnamesetter.BuildNameSetter>
   </buildWrappers>
   <prebuilders/>

--- a/jobs/db-schema/config.xml
+++ b/jobs/db-schema/config.xml
@@ -125,6 +125,8 @@
   <buildWrappers>
     <org.jenkinsci.plugins.buildnamesetter.BuildNameSetter plugin="build-name-setter@1.3">
       <template>${GIT_REVISION,length=8}</template>
+      <runAtStart>true</runAtStart>
+      <runAtEnd>true</runAtEnd>
     </org.jenkinsci.plugins.buildnamesetter.BuildNameSetter>
   </buildWrappers>
 </project>

--- a/jobs/doc/config.xml
+++ b/jobs/doc/config.xml
@@ -142,6 +142,8 @@ nanoc compile</command>
   <buildWrappers>
     <org.jenkinsci.plugins.buildnamesetter.BuildNameSetter plugin="build-name-setter@1.3">
       <template>${GIT_REVISION,length=8}</template>
+      <runAtStart>true</runAtStart>
+      <runAtEnd>true</runAtEnd>
     </org.jenkinsci.plugins.buildnamesetter.BuildNameSetter>
   </buildWrappers>
 </project>

--- a/jobs/flume/config.xml
+++ b/jobs/flume/config.xml
@@ -134,6 +134,8 @@
   <buildWrappers>
     <org.jenkinsci.plugins.buildnamesetter.BuildNameSetter plugin="build-name-setter@1.3">
       <template>${GIT_REVISION,length=8}</template>
+      <runAtStart>true</runAtStart>
+      <runAtEnd>true</runAtEnd>
     </org.jenkinsci.plugins.buildnamesetter.BuildNameSetter>
   </buildWrappers>
   <prebuilders>

--- a/jobs/inductor/config.xml
+++ b/jobs/inductor/config.xml
@@ -141,6 +141,8 @@
   <buildWrappers>
     <org.jenkinsci.plugins.buildnamesetter.BuildNameSetter plugin="build-name-setter@1.3">
       <template>${GIT_REVISION,length=8}</template>
+      <runAtStart>true</runAtStart>
+      <runAtEnd>true</runAtEnd>
     </org.jenkinsci.plugins.buildnamesetter.BuildNameSetter>
   </buildWrappers>
   <prebuilders/>

--- a/jobs/jenkins-plugin/config.xml
+++ b/jobs/jenkins-plugin/config.xml
@@ -134,6 +134,8 @@ jpi build</command>
     </ruby-proxy-object>
     <org.jenkinsci.plugins.buildnamesetter.BuildNameSetter plugin="build-name-setter@1.3">
       <template>${GIT_REVISION,length=8}</template>
+      <runAtStart>true</runAtStart>
+      <runAtEnd>true</runAtEnd>
     </org.jenkinsci.plugins.buildnamesetter.BuildNameSetter>
   </buildWrappers>
 </project>

--- a/jobs/oneops-admin/config.xml
+++ b/jobs/oneops-admin/config.xml
@@ -132,6 +132,8 @@
   <buildWrappers>
     <org.jenkinsci.plugins.buildnamesetter.BuildNameSetter plugin="build-name-setter@1.3">
       <template>${GIT_REVISION,length=8}</template>
+      <runAtStart>true</runAtStart>
+      <runAtEnd>true</runAtEnd>
     </org.jenkinsci.plugins.buildnamesetter.BuildNameSetter>
   </buildWrappers>
 </project>

--- a/jobs/oneops/config.xml
+++ b/jobs/oneops/config.xml
@@ -124,6 +124,8 @@
   <buildWrappers>
     <org.jenkinsci.plugins.buildnamesetter.BuildNameSetter plugin="build-name-setter@1.3">
       <template>${GIT_REVISION,length=8}</template>
+      <runAtStart>true</runAtStart>
+      <runAtEnd>true</runAtEnd>
     </org.jenkinsci.plugins.buildnamesetter.BuildNameSetter>
   </buildWrappers>
 </project>

--- a/jobs/opamp/config.xml
+++ b/jobs/opamp/config.xml
@@ -143,6 +143,8 @@
   <buildWrappers>
     <org.jenkinsci.plugins.buildnamesetter.BuildNameSetter plugin="build-name-setter@1.3">
       <template>${GIT_REVISION,length=8}</template>
+      <runAtStart>true</runAtStart>
+      <runAtEnd>true</runAtEnd>
     </org.jenkinsci.plugins.buildnamesetter.BuildNameSetter>
   </buildWrappers>
   <prebuilders/>

--- a/jobs/package/config.xml
+++ b/jobs/package/config.xml
@@ -220,6 +220,8 @@ shasum -a 256 oneops-$VERSION.tar.gz &gt; oneops-$VERSION.tar.gz.sha1</command>
   <buildWrappers>
     <org.jenkinsci.plugins.buildnamesetter.BuildNameSetter plugin="build-name-setter@1.5.1">
       <template>${ENV,var=&quot;VERSION&quot;}</template>
+      <runAtStart>true</runAtStart>
+      <runAtEnd>true</runAtEnd>
     </org.jenkinsci.plugins.buildnamesetter.BuildNameSetter>
   </buildWrappers>
 </project>

--- a/jobs/search/config.xml
+++ b/jobs/search/config.xml
@@ -152,6 +152,8 @@
   <buildWrappers>
     <org.jenkinsci.plugins.buildnamesetter.BuildNameSetter plugin="build-name-setter@1.3">
       <template>${GIT_REVISION,length=8}</template>
+      <runAtStart>true</runAtStart>
+      <runAtEnd>true</runAtEnd>
     </org.jenkinsci.plugins.buildnamesetter.BuildNameSetter>
   </buildWrappers>
   <prebuilders/>

--- a/jobs/sensor/config.xml
+++ b/jobs/sensor/config.xml
@@ -143,6 +143,8 @@
   <buildWrappers>
     <org.jenkinsci.plugins.buildnamesetter.BuildNameSetter plugin="build-name-setter@1.3">
       <template>${GIT_REVISION,length=8}</template>
+      <runAtStart>true</runAtStart>
+      <runAtEnd>true</runAtEnd>
     </org.jenkinsci.plugins.buildnamesetter.BuildNameSetter>
   </buildWrappers>
   <prebuilders/>

--- a/jobs/transistor/config.xml
+++ b/jobs/transistor/config.xml
@@ -142,6 +142,8 @@
   <buildWrappers>
     <org.jenkinsci.plugins.buildnamesetter.BuildNameSetter plugin="build-name-setter@1.3">
       <template>${GIT_REVISION,length=8}</template>
+      <runAtStart>true</runAtStart>
+      <runAtEnd>true</runAtEnd>
     </org.jenkinsci.plugins.buildnamesetter.BuildNameSetter>
   </buildWrappers>
   <prebuilders/>

--- a/jobs/transmitter/config.xml
+++ b/jobs/transmitter/config.xml
@@ -142,6 +142,8 @@
   <buildWrappers>
     <org.jenkinsci.plugins.buildnamesetter.BuildNameSetter plugin="build-name-setter@1.3">
       <template>${GIT_REVISION,length=8}</template>
+      <runAtStart>true</runAtStart>
+      <runAtEnd>true</runAtEnd>
     </org.jenkinsci.plugins.buildnamesetter.BuildNameSetter>
   </buildWrappers>
   <prebuilders/>


### PR DESCRIPTION
…buildnamesetter plugin update is put in central. Relates to #6 