### PR TITLE
updating jenkins version

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -23,7 +23,7 @@ def updates
 end
 
 def version
-  "1.642.1"
+  "1.642.4"
 end
 
 ENV['JENKINS_HOME'] = build_root


### PR DESCRIPTION
jenkins version 1.642.1 no longer exists at that mirror.  Updating to use a new version that does.

Error from a fresh `vagrant up` from the setup repo
```
==> default: Downloading jenkins war: http://mirror.xmission.com/jenkins/war-stable/1.642.1/jenkins.war
==> default: rake aborted!
==> default: OpenURI::HTTPError: 404 Not Found
```