### PR TITLE
Moving back to the Jenkins mirror.  The xmission.com mirrors continue…

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,8 +9,8 @@ def build_root
 end
 
 def mirror
-  #"http://mirrors.jenkins-ci.org"
-  "http://mirror.xmission.com/jenkins"
+  "http://mirrors.jenkins-ci.org"
+  #"http://mirror.xmission.com/jenkins"
 end
 
 def oneops
@@ -18,8 +18,8 @@ def oneops
 end
 
 def updates
-  #"http://updates.jenkins-ci.org/stable"
-  "http://mirror.xmission.com/jenkins/updates"
+  "http://updates.jenkins-ci.org/stable"
+  #"http://mirror.xmission.com/jenkins/updates"
 end
 
 def version


### PR DESCRIPTION
… to drop versions and they've rolled over to the 2.x versions.